### PR TITLE
Add arm64 support for DCGM

### DIFF
--- a/snap/local/configure_sources.sh
+++ b/snap/local/configure_sources.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+DISTRIBUTION="ubuntu2404"
+SYSTEM_ARCH=$(uname -m)
+# package that configures the apt source
+CUDA_PKG="cuda-keyring_1.1-1_all.deb"
+
+if [ "$SYSTEM_ARCH" = "aarch64" ]; then
+    ARCH="sbsa"
+    SHA256SUM="6ea7d2737648936820e85677177957a0f6521b840d98eb0bbae0a4f003fa7249"
+elif [ "$SYSTEM_ARCH" = "x86_64" ]; then
+    ARCH="x86_64"
+    SHA256SUM="d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba"
+else
+    echo "Unsupported architecture: $SYSTEM_ARCH"
+    exit 1
+fi
+
+
+echo "Architecture is $SYSTEM_ARCH. Downloading cuda-keyring package..."
+wget "https://developer.download.nvidia.com/compute/cuda/repos/$DISTRIBUTION/$ARCH/$CUDA_PKG"
+
+# Run the checksum verification and install cuda-keyring if valid
+if echo "$SHA256SUM  $CUDA_PKG" | sha256sum --check --status; then
+    echo "Checksum for $CUDA_PKG is correct."
+    dpkg -i $CUDA_PKG
+    apt-get update
+else
+    echo "Checksum for $CUDA_PKG is incorrect."
+    exit 1
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,13 +16,6 @@ source-code: https://github.com/canonical/dcgm-snap
 issues: https://github.com/canonical/dcgm-snap/issues
 title: NVIDIA DCGM
 
-package-repositories:
-  - type: apt
-    path: /
-    formats: [deb]
-    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64
-
 apps:
   dcgm-exporter:
     command: bin/dcgm-exporter
@@ -57,7 +50,17 @@ parts:
     override-build: |
       craftctl default
       chmod +x run_nv_hostengine.sh
+  configure-sources:
+    plugin: dump
+    source: snap/local
+    build-packages:
+      - wget
+      - dpkg
+    override-build: |
+      ./configure_sources.sh
   dcgm-exporter:
+    after:
+      - configure-sources
     plugin: go
     stage-packages: [datacenter-gpu-manager]
     build-snaps:


### PR DESCRIPTION
Download the `cuda-keyring_1.1-1_all.deb` package depending on the architecture of the system, check the sha256sum and install if valid. This package will configure the apt sources and it's the recommended way by the [documentation](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#ubuntu-lts-and-debian)