### PR TITLE
Add GH to Jira automation

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -15,7 +15,7 @@ settings:
   # (Optional) Jira project components that should be attached to the created issue
   # Component names are case-sensitive
   components:
-    - hardware-observer
+    - dcgm
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
   epic_key: SOLENG-46

--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,26 @@
+#
+# For more info about the settings, please refre to the github repository:
+# https://github.com/canonical/gh-jira-sync-bot
+#
+
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "SOLENG"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - hardware-observer
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: SOLENG-46
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story


### PR DESCRIPTION
Adds the bot to the dcgm-snap repo so that new bugs can automatically appear in jira.