### PR TITLE
Add arm64 on platforms

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ platforms:
   amd64:
     build-on: [amd64]
     build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
 grade: stable
 confinement: strict
 source-code: https://github.com/canonical/dcgm-snap


### PR DESCRIPTION
Without adding arm64 on metadata the snapcraft is not able to properly build the snap.