### PR TITLE
Snapstore Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ You can build the snap locally by using the command:
 ```shell
 snapcraft --use-lxd
 ```
+
+## Test
+
+You can test the snap locally by using the command:
+
+```shell
+tox -e func
+```
+
+User facing documentation can be found in the [snapcraft documentation](https://snapcraft.io/dcgm).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,8 +5,62 @@ summary: Snap for NVIDIA DCGM and DCGM exporter
 license: Apache-2.0
 contact: solutions-engineering@lists.canonical.com
 description: |
-  This snap includes NVIDIA DCGM and DCGM exporter to provide GPU monitoring via
-  Prometheus metrics. This snap does not include the dcgmproftester.
+  This snap includes NVIDIA DCGM and DCGM-exporter to monitor GPU via Prometheus metrics.
+  This snap does not include the `dcgmproftester`.
+
+  **Note**: The `DCGM-exporter` service is disabled by default because a user might not be interested 
+  in collecting metrics as this is a dcgm snap, not the DCGM-exporter snap.
+
+  **Quick Start**
+  ---
+  Getting the NVIDIA GPU metrics would look like this:
+
+  ```
+  # Install the snap
+  sudo snap install dcgm
+
+  # Start the DCGM exporter service
+  sudo snap start dcgm.dcgm-exporter
+
+  # Get the default metrics
+  curl localhost:9400/metrics
+  ```
+
+  **Config**
+  ---
+  The DCGM snap provides several configuration options through the snap.
+
+  ```
+  # Get all the configuration options
+  sudo snap get dcgm
+
+  # Example of setting the NV-Hostengine port
+  sudo snap set dcgm nv-hostengine-port=5577
+
+  # Restart the NV-Hostengine service to apply the changes
+  sudo snap restart dcgm.nv-hostengine
+  ```
+
+  Available configs:
+  - `nv-hostengine-port`: The port on which the NV-Hostengine listens. 
+    The default is 5555.
+  - `dcgm-exporter-address`: The bind address which the DCGM exporter exposes for the metrics. 
+    The default is :9400.
+  - `dcgm-exporter-metrics-file`: The name of the custom CSV metrics file can be provided (only the name, not the path).
+    The file should be placed in the `/var/snap/dcgm/common/` directory. 
+    The default is located in `/snap/dcgm/current/etc/dcgm-exporter/default-counters.csv`.
+    Please refer to the DCGM-Exporter repository for more information on the CSV file format.
+
+  **Links**
+  ---
+  Upstream DCGM-Exporter repository for more information
+  https://github.com/NVIDIA/dcgm-exporter
+
+  Upstream DCGM repository
+  https://github.com/NVIDIA/DCGM
+
+  All NVIDIA metrics
+  https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html
 platforms:
   amd64:
     build-on: [amd64]


### PR DESCRIPTION
Adds user documentation to the `snapcraft.yaml`.