### PR TITLE
Add hardware-observe plug to the snap apps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,6 +102,7 @@ apps:
     plugs:
       - network-bind
       - opengl
+      - hardware-observe
     daemon: simple
     # As this is a dcgm snap, not the dcgm-exporter snap,
     # user might not be interested in running dcgm-exporter, so disable it by default
@@ -112,11 +113,13 @@ apps:
     plugs:
       - network-bind
       - opengl
+      - hardware-observe
   nv-hostengine:
     command: bin/run_nv_hostengine.sh
     plugs:
       - network-bind
       - opengl
+      - hardware-observe
     daemon: simple
     restart-condition: on-abort
     environment:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,6 +13,9 @@ def install_dcgm_snap():
         shell=True,
     )
 
+    # Manually connect the 'hardware-observe' interface as auto-connect is not allowed
+    subprocess.check_call("sudo snap connect dcgm:hardware-observe".split())
+
     subprocess.check_call("sudo snap start dcgm.dcgm-exporter".split())
 
     yield


### PR DESCRIPTION
Adds a `hardware-observer` plug to allow the snap to collect PCIE and DCP metrics. Without the plug, the `dcgm-exporter` fails to start on some machines with the following error message:

```
Failed to watch metrics: Error watching fields: Host engine is running as non-root
```

The plug allows the `dcgm-exporter` to start usually and collect all metrics, even [custom ones](https://github.com/Deezzir/dcgm-snap/blob/metrics/snap/local/dcgm-custom-metrics.csv).