### PR TITLE
Remove the build on release once this is done on check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
-      - uses: canonical/action-build@v1
-        id: build
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,25 +17,22 @@ jobs:
     secrets: inherit
 
   release:
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-22.04
     needs: check
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
+        archs: ["aarch64", "x86_64"]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Complete git history is required to generate the version from git tags.
-      - name: Determine system architecture
-        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
       - name: Download the built snap from check workflow
         uses: actions/download-artifact@v4
         with:
-          name: snap_${{ env.SYSTEM_ARCH }}
+          name: snap_${{ matrix.archs }}
+      - name: Determine file name
+        run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: snap_${{ env.SYSTEM_ARCH }}
+          snap: ${{ env.SNAP_FILE }}
           release: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,15 +27,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Download the built snap from check workflow
         uses: actions/download-artifact@v4
         with:
           name: snap_${{ env.SYSTEM_ARCH }}
+
+      - name: Find the downloaded snap file
+        run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV
+
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: snap_${{ env.SYSTEM_ARCH }}
+          snap: ${{ env.SNAP_FILE }}
           release: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,22 +17,25 @@ jobs:
     secrets: inherit
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     needs: check
     strategy:
       fail-fast: false
       matrix:
-        archs: ["aarch64", "x86_64"]
+        runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Complete git history is required to generate the version from git tags.
+      - name: Determine system architecture
+        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
       - name: Download the built snap from check workflow
         uses: actions/download-artifact@v4
         with:
-          name: snap_${{ matrix.archs }}
-      - name: Determine file name
-        run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV
+          name: snap_${{ env.SYSTEM_ARCH }}
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: ${{ env.SNAP_FILE }}
+          snap: snap_${{ env.SYSTEM_ARCH }}
           release: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,21 +23,19 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [[ubuntu-22.04], [self-hosted, jammy, ARM64]]
-    outputs:
-      snap: ${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
+      - name: Download the built snap from check workflow
+        uses: actions/download-artifact@v4
         with:
           name: snap_${{ env.SYSTEM_ARCH }}
-          path: ${{ steps.build.outputs.snap }}
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: snap_${{ env.SYSTEM_ARCH }}
           release: latest/edge


### PR DESCRIPTION
- building two times in the same run result into conflicts in Github action.