### PR TITLE
Update tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = lint, unit, func
+envlist = lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
- `unit` doesn't exist
- avoid running `func` tests by default (one may not wish to run func tests on their workstation, so it may be dangerous to run it by default)