### PR TITLE
Fix dcgmi diag

### DIFF
--- a/snap/local/files/run_nv_hostengine.sh
+++ b/snap/local/files/run_nv_hostengine.sh
@@ -19,5 +19,5 @@ if [ "$dcgm_exporter_status" == "active" ]; then
 fi
 
 export NVVS_BIN_PATH="${SNAP}/usr/share/nvidia-validation-suite/"
-export LD_LIBRARY_PATH="${SNAP}/usr/lib/x86_64-linux-gnu/"
+export LD_LIBRARY_PATH="${SNAP}/usr/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}"
 exec "$SNAP/usr/bin/nv-hostengine" -n --service-account nvidia-dcgm "${args[@]}"

--- a/snap/local/files/run_nv_hostengine.sh
+++ b/snap/local/files/run_nv_hostengine.sh
@@ -18,4 +18,6 @@ if [ "$dcgm_exporter_status" == "active" ]; then
     snapctl restart dcgm.dcgm-exporter
 fi
 
+export NVVS_BIN_PATH="${SNAP}/usr/share/nvidia-validation-suite/"
+export LD_LIBRARY_PATH="${SNAP}/usr/lib/x86_64-linux-gnu/"
 exec "$SNAP/usr/bin/nv-hostengine" -n --service-account nvidia-dcgm "${args[@]}"

--- a/snap/local/files/run_nv_hostengine.sh
+++ b/snap/local/files/run_nv_hostengine.sh
@@ -18,6 +18,4 @@ if [ "$dcgm_exporter_status" == "active" ]; then
     snapctl restart dcgm.dcgm-exporter
 fi
 
-export NVVS_BIN_PATH="${SNAP}/usr/share/nvidia-validation-suite/"
-export LD_LIBRARY_PATH="${SNAP}/usr/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}"
 exec "$SNAP/usr/bin/nv-hostengine" -n --service-account nvidia-dcgm "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,6 +84,9 @@ platforms:
   arm64:
     build-on: [arm64]
     build-for: [arm64]
+environment:
+  NVVS_BIN_PATH: $SNAP/usr/share/nvidia-validation-suite/
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/usr/lib/x86_64-linux-gnu/
 grade: stable
 confinement: strict
 source-code: https://github.com/canonical/dcgm-snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,6 @@ platforms:
     build-for: [arm64]
 environment:
   NVVS_BIN_PATH: $SNAP/usr/share/nvidia-validation-suite/
-  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/usr/lib/x86_64-linux-gnu/
 grade: stable
 confinement: strict
 source-code: https://github.com/canonical/dcgm-snap


### PR DESCRIPTION
In order to have the dcgmi diag it is necessary to set the right path for the NVVS_BIN_PATH

Command before this change:

```shell
dcgm.dcgmi diag -r 1 -g 0 
Error when executing the diagnostic: The NVVS binary was not found in the specified location; please install it to /usr/share/nvidia-validation-suite/ or set environment variable NVVS_BIN_PATH to the directory containing nvvs. If you set NVVS_BIN_PATH, please restart the DCGM service (nv-hostengine) if it is active.
Nvvs stderr:
```

Command after this change:
```shell
dcgm.dcgmi diag -r 1 -g 0 
Error when executing the diagnostic: Generic unspecified error
Nvvs stderr:
```

The problem that is showing after the fix, probably it's because my personal laptop doesn't have a server graded GPU
