### PR TITLE
Introduce TICS workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo apt update
           python -m pip install --upgrade pip
+          # tics action requires flake8 to be installed on the runner
           python -m pip install flake8
           # pin tox to the current major version to avoid
           # workflows breaking all at once when a new major version is released.

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -38,6 +38,7 @@ jobs:
           sudo apt update
           python -m pip install --upgrade pip
           # tics action requires flake8 to be installed on the runner
+          # https://github.com/tiobe/tics-github-action/issues/410
           python -m pip install flake8
           # pin tox to the current major version to avoid
           # workflows breaking all at once when a new major version is released.

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -50,7 +50,7 @@ jobs:
           name: snap_artifact
 
       - name: Test with tox and produce coverage report
-        run: tox -e test-all
+        run: tox -e tics
 
       - name: Run TICS analysis
         uses: tiobe/tics-github-action@v3

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,0 +1,61 @@
+name: TICS
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify snap builds successfully
+        id: build
+        uses: canonical/action-build@v1
+
+      - name: Upload the built snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap_artifact
+          path: ${{ steps.build.outputs.snap }}
+
+  tics-report:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+          # pin tox to the current major version to avoid
+          # workflows breaking all at once when a new major version is released.
+          python -m pip install 'tox<5'
+
+      - name: Get the snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap_artifact
+
+      - name: Test with tox and produce coverage report
+        run: tox -e test-all
+
+      - name: Run TICS analysis
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: dcgm-snap
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          branchdir: ${{ github.workspace }}
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,21 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 deps = {[testenv:lint]deps}
 commands =
     black .
     isort .
+
+[testenv:test-all]
+deps =
+    pytest
+    pytest-cov
+    -r {toxinidir}/tests/functional/requirements.txt
+allowlist_externals = mkdir
+commands_pre = mkdir -p tests/report
+commands =
+    pytest {toxinidir}/tests \
+    {posargs:-v --cov --cov-report=xml:tests/report/coverage.xml --junit-xml=tests/report/tests.xml}
 
 [testenv:func]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     black .
     isort .
 
-[testenv:test-all]
+[testenv:tics]
 base = testenv
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -32,15 +32,14 @@ commands =
     isort .
 
 [testenv:test-all]
+base = testenv
 deps =
     pytest
     pytest-cov
-    -r {toxinidir}/tests/functional/requirements.txt
-allowlist_externals = mkdir
-commands_pre = mkdir -p tests/report
+description = Run all tests for snap and produce coverage report
 commands =
     pytest {toxinidir}/tests \
-    {posargs:-v --cov --cov-report=xml:tests/report/coverage.xml --junit-xml=tests/report/tests.xml}
+    -v --cov --cov-report=xml:{toxinidir}/tests/report/coverage.xml --junit-xml={toxinidir}/tests/report/tests.xml
 
 [testenv:func]
 deps =


### PR DESCRIPTION
Adds the workflow, allowing the TICS report to be generated every time there is a push to the main. Additionally, the workflow can be triggered manually.

Additionally, we can centrally manage the workflow later.

https://github.com/canonical/solutions-engineering-automation/issues/115