### PR TITLE
Add snap repo git revision to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -174,9 +174,10 @@ parts:
 
       # Extract the version from the .deb file
       DCGM_VERSION=$(dpkg-deb -f "$DEB_FILE" Version)
+      GIT_VERSION=$(git -C $CRAFT_PROJECT_DIR describe --always --dirty --abbrev=10)
 
       # Set the Snap version to the same as dcgm deb file
-      craftctl set version="${DCGM_VERSION#1:}"
+      craftctl set version="${DCGM_VERSION#1:}+snap-${GIT_VERSION}"
 
   # This is the DCGM exporter
   dcgm-exporter:


### PR DESCRIPTION
This will help identify which revision of this snap source was used to build a snap revision.

For reference, this will result in a snap file like `dcgm_3.3.8+snap-f5a97654f5-dirty_amd64.snap` (or `dcgm_3.3.8+snap-f5a97654f5_amd64.snap` for a clean checkout).