### PR TITLE
Add permission to read and write nvidia-persistenced socket

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -119,6 +119,14 @@ source-code: https://github.com/canonical/dcgm-snap
 issues: https://github.com/canonical/dcgm-snap/issues
 title: NVIDIA DCGM
 
+plugs:
+  nvidia-driver-daemon:
+    interface: system-files
+    read:
+      - /run/nvidia-persistenced/socket
+    write:
+      - /run/nvidia-persistenced/socket
+
 apps:
   dcgm-exporter:
     command: bin/run_dcgm_exporter.sh
@@ -143,6 +151,8 @@ apps:
       - network-bind
       - opengl
       - hardware-observe
+      - nvidia-driver-daemon
+      - log-observe
     daemon: simple
     restart-condition: on-abort
     environment:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -16,6 +16,8 @@ def install_dcgm_snap():
     # Manually connect the 'hardware-observe' interface as auto-connect is not allowed
     subprocess.check_call("sudo snap connect dcgm:hardware-observe".split())
     subprocess.check_call("sudo snap connect dcgm:opengl".split())
+    subprocess.check_call("sudo snap connect dcgm:nvidia-driver-daemon".split())
+    subprocess.check_call("sudo snap connect dcgm:log-observe".split())
 
     subprocess.check_call("sudo snap start dcgm.dcgm-exporter".split())
 


### PR DESCRIPTION
Without this permissions in nv-hostengine, dcgmi cannot run adequate tests to check the GPUs
Closes: #68