### PR TITLE
Add support for a snap config to enable autostart of exporter service

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -12,18 +12,6 @@ dcgm_exporter_metrics_file="$(snapctl get dcgm-exporter-metrics-file)"
 # Usage: snap set dcgm exporter.autostart=true
 autostart="$(snapctl get exporter.autostart)"
 
-# Handle the 'Disabled' or 'Unset' state
-# We default to 'stop --disable' if the value is false or empty.
-# This ensures that Port 9400 is only claimed upon explicit user request.
-if [[ "$autostart" = "false" ]] || [[ -z "$autostart" ]]; then
-    snapctl stop --disable dcgm.dcgm-exporter
-
-# Handle the 'Enabled' state
-# When set to true, the service is started and set to persist across reboots.
-elif [[ "$autostart" = "true" ]]; then
-    snapctl start --enable dcgm.dcgm-exporter
-fi
-
 if [[ -z "$nv_hostengine_port" ]]; then
     # Explicitly use the default bind port of nv-hostengine
     snapctl set nv-hostengine-port="5555"
@@ -66,3 +54,14 @@ else
     fi
 fi
 
+# Handle the 'Disabled' or 'Unset' state
+# We default to 'stop --disable' if the value is false or empty.
+# This ensures that Port 9400 is only claimed upon explicit user request.
+if [[ "$autostart" = "false" ]] || [[ -z "$autostart" ]]; then
+    snapctl stop --disable dcgm.dcgm-exporter
+
+# Handle the 'Enabled' state
+# When set to true, the service is started and set to persist across reboots.
+elif [[ "$autostart" = "true" ]]; then
+    snapctl start --enable dcgm.dcgm-exporter
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -8,6 +8,22 @@ nv_hostengine_port="$(snapctl get nv-hostengine-port)"
 dcgm_exporter_address="$(snapctl get dcgm-exporter-address)"
 dcgm_exporter_metrics_file="$(snapctl get dcgm-exporter-metrics-file)"
 
+# Retrieve the user-defined configuration for autostart
+# Usage: snap set dcgm exporter.autostart=true
+autostart="$(snapctl get exporter.autostart)"
+
+# Handle the 'Disabled' or 'Unset' state
+# We default to 'stop --disable' if the value is false or empty.
+# This ensures that Port 9400 is only claimed upon explicit user request.
+if [[ "$autostart" = "false" ]] || [[ -z "$autostart" ]]; then
+    snapctl stop --disable dcgm.dcgm-exporter
+
+# Handle the 'Enabled' state
+# When set to true, the service is started and set to persist across reboots.
+elif [[ "$autostart" = "true" ]]; then
+    snapctl start --enable dcgm.dcgm-exporter
+fi
+
 if [[ -z "$nv_hostengine_port" ]]; then
     # Explicitly use the default bind port of nv-hostengine
     snapctl set nv-hostengine-port="5555"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -54,6 +54,7 @@ else
     fi
 fi
 
+# If 'autostart' is empty (default), this entire block is skipped.
 # Handle the 'Disabled' state
 if [[ "$autostart" = "false" ]]; then
     snapctl stop --disable dcgm.dcgm-exporter

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -54,10 +54,8 @@ else
     fi
 fi
 
-# Handle the 'Disabled' or 'Unset' state
-# We default to 'stop --disable' if the value is false or empty.
-# This ensures that Port 9400 is only claimed upon explicit user request.
-if [[ "$autostart" = "false" ]] || [[ -z "$autostart" ]]; then
+# Handle the 'Disabled' state
+if [[ "$autostart" = "false" ]]; then
     snapctl stop --disable dcgm.dcgm-exporter
 
 # Handle the 'Enabled' state


### PR DESCRIPTION
Objective : 

Enable the `dcgm-exporter` service to be started via native snap configuration.

This allows for the declarative management of the service in orchestrated environments, reducing the need for manual intervention to start the service after the initial snap installation.

Key Changes : 

Introduce explicit control over the 'dcgm-exporter' service via standard snap configuration hook.

- snap set dcgm-snap exporter.autostart=true (Starts and enables the service)

- snap set dcgm-snap exporter.autostart=false (Stops and disables the service)