### PR TITLE
Add support for exporter service to start at installation when using custom gadget snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ In your gadget snap's `defaults` section:
 
 ```YAML
 defaults:
-  <snap-id>:
+  #dcgm snap ID
+  e2YXZYWeF3P3divT2g7G5mxaqAmPVZxj:
     exporter:
       autostart: true
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ You can build the snap locally by using the command:
 snapcraft pack -v
 ```
 
+## Configuration
+
+The snap supports a default-configure hook which runs once during the installation of the snap to allow automated startup of dcgm-exporter service, particularly useful when deployed with a custom gadget snap.
+
+# Autostart via Gadget Snap
+
+If the exporter.autostart configuration is set to true by a gadget snap, the dcgm-exporter service will be enabled and started automatically upon installation.Gadget Snap Configuration Example:
+In your gadget snap's defaults section:
+
+YAML
+defaults:
+  <snap-id>:
+    exporter:
+      autostart: true
+
 ## Test
 
 You can test the snap locally by using the command:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ snapcraft pack -v
 
 ## Configuration
 
-The snap supports a `default-configure` hook which runs once during the installation of the snap to allow automated startup of dcgm-exporter service, particularly useful when deployed with a custom gadget snap.
+The snap supports a `default-configure` hook which runs once during the installation of the snap to allow automated startup of `dcgm-exporter` service. This is particularly useful when deployed with a custom gadget snap , as it helps override the default service status of the exporter (which is disabled at installation).
 
 ### Autostart via Gadget Snap
 
-If the `exporter.autostart` configuration is set to `true` by a gadget snap, the dcgm-exporter service will be enabled and started automatically upon installation.Gadget Snap Configuration Example:
-In your gadget snap's defaults section:
+If the `exporter.autostart` configuration is set to `true` by a gadget snap, the `dcgm-exporter` service will be enabled and started automatically upon installation.
+
+#### Gadget Snap Configuration Example:
+
+In your gadget snap's `defaults` section:
 
 ```YAML
 defaults:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ defaults:
   <snap-id>:
     exporter:
       autostart: true
+```
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ snapcraft pack -v
 
 ## Configuration
 
-The snap supports a default-configure hook which runs once during the installation of the snap to allow automated startup of dcgm-exporter service, particularly useful when deployed with a custom gadget snap.
+The snap supports a `default-configure` hook which runs once during the installation of the snap to allow automated startup of dcgm-exporter service, particularly useful when deployed with a custom gadget snap.
 
-# Autostart via Gadget Snap
+### Autostart via Gadget Snap
 
-If the exporter.autostart configuration is set to true by a gadget snap, the dcgm-exporter service will be enabled and started automatically upon installation.Gadget Snap Configuration Example:
+If the `exporter.autostart` configuration is set to `true` by a gadget snap, the dcgm-exporter service will be enabled and started automatically upon installation.Gadget Snap Configuration Example:
 In your gadget snap's defaults section:
 
-YAML
+```YAML
 defaults:
   <snap-id>:
     exporter:

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -50,3 +50,9 @@ else
     fi
 fi
 
+# If configuration option exporter.autostart is set to true, start the exporter service
+autostart="$(snapctl get exporter.autostart)"
+
+if [ "$autostart" = "true" ]; then
+    snapctl start --enable dcgm.dcgm-exporter
+fi

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# If exporter.autostart is set to true in gadget snap, the exporter service is started at installation of dcgm snap
+
+autostart="$(snapctl get exporter.autostart)"
+
+[ "$autostart" = "true" ] && snapctl start --enable dcgm.dcgm-exporter

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-# If exporter.autostart is set to true in gadget snap, the exporter service is started at installation of dcgm snap
+# If exporter.autostart is set to true in gadget snap, write the key permanently into snapd's local database
 
 autostart="$(snapctl get exporter.autostart)"
 
-[ "$autostart" = "true" ] && snapctl start --enable dcgm.dcgm-exporter
+if [ "$autostart" = "true" ]; then
+    snapctl set exporter.autostart=true
+fi


### PR DESCRIPTION
This PR implements a default-configure hook to check for a config named `exporter.autostart`.
This allows the `dcgm-exporter` service to be enabled and started automatically during the initial installation when pre-configured by a gadget snap.

Changes :

Added snap/hooks/default-configure script.
Implemented logic to read `exporter.autostart` using `snapctl`.
Conditionally enables and starts the `dcgm-exporter` service if the config value is true in gadget snap.